### PR TITLE
Add aria labels to GitHub profile button and link.

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -140,8 +140,12 @@ const MyApp: AppType = ({ Component, pageProps }) => {
             </NavigationMenu>
 
             <div className="ml-auto md:ml-0">
-              <Link href="https://github.com/STBoyden" passHref>
-                <Button size="icon">
+              <Link
+                aria-label="GitHub profile link"
+                href="https://github.com/STBoyden"
+                passHref
+              >
+                <Button aria-label="GitHub profile button" size="icon">
                   <Github className="h-4 w-4" />
                 </Button>
               </Link>


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request improves accessibility by adding `aria-label` attributes to the GitHub profile link and button in the `_app.tsx` file.
> 
> ## What changed
> The GitHub profile link and button in the `_app.tsx` file were updated to include `aria-label` attributes. This provides a description of the link and button to assistive technologies, such as screen readers, improving the accessibility of the website.
> 
> ```diff
> -              <Link href="https://github.com/STBoyden" passHref>
> -                <Button size="icon">
> +              <Link
> +                aria-label="GitHub profile link"
> +                href="https://github.com/STBoyden"
> +                passHref
> +              >
> +                <Button aria-label="GitHub profile button" size="icon">
>                    <Github className="h-4 w-4" />
>                  </Button>
>                </Link>
> ```
> 
> ## How to test
> 1. Open the website and navigate to the page where the GitHub profile link and button are displayed.
> 2. Use a screen reader or other assistive technology to interact with the link and button. The `aria-label` descriptions should be read out.
> 
> ## Why make this change
> Improving accessibility is important to ensure that all users, including those with disabilities, can use the website effectively. Adding `aria-label` attributes to links and buttons provides additional context that can be helpful for users who rely on assistive technologies.
</details>