### PR TITLE
Add typography components as per shadcn/ui, use on index page

### DIFF
--- a/src/components/typography.tsx
+++ b/src/components/typography.tsx
@@ -1,0 +1,71 @@
+export function Header1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="scroll-m-20 text-4xl lg:text-5xl font-extrabold tracking-tight">
+      {children}
+    </h1>
+  );
+}
+
+export function Header2({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
+      {children}
+    </h2>
+  );
+}
+
+export function Header3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mt-5 scroll-m-20 text-2xl font-semibold tracking-tight first:mt-0">
+      {children}
+    </h3>
+  );
+}
+
+export function Header4({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="mt-5 scroll-m-20 text-xl font-semibold tracking-tight first:mt-0">
+      {children}
+    </h4>
+  );
+}
+
+export function Paragraph({ children }: { children: React.ReactNode }) {
+  return <p className="leading-7 [&:not(:first-child)]:mt-6">{children}</p>;
+}
+
+export function Blockquote({ children }: { children: React.ReactNode }) {
+  return (
+    <blockquote className="mt-6 border-l-2 pl-6 italic">{children}</blockquote>
+  );
+}
+
+export function List({
+  children,
+}: {
+  children:
+    | React.ReactElement<JSX.IntrinsicElements["li"]>
+    | React.ReactElement<JSX.IntrinsicElements["li"]>[];
+}) {
+  return <ul className="my-6 ml-6 list-disc [&>li]:mt-2">{children}</ul>;
+}
+
+export function InlineCode({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
+      {children}
+    </code>
+  );
+}
+
+export function ParagraphLead({ children }: { children: React.ReactNode }) {
+  return <p className="text-xl text-muted-foreground">{children}</p>;
+}
+
+export function Large({ children }: { children: React.ReactNode }) {
+  return <div className="text-lg font-semibold">{children}</div>;
+}
+
+export function Small({ children }: { children: React.ReactNode }) {
+  return <small className="text-sm font-medium leading-none">{children}</small>;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { ImageWithFallback } from "@/components/image-with-fallback";
+import * as Typography from "@/components/typography";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { Button } from "@/components/ui/button";
 import {
@@ -70,22 +71,25 @@ export default function Home() {
           )}
 
           <span className="lg:ml-2 lg:border-l-2 lg:pl-2">
-            I am an aspiring software developer, currently studying a BSc
-            Computer Science degree, in my final year. I am self-taught in
-            programming, and have a strong focus on full-stack, with experience
-            using UNIX-based systems (Linux, and MacOS) and Windows.
-            <br />
-            <br />
-            This website functions as a portfolio website for future employment
-            (please see the{" "}
-            <Link
-              href="/projects"
-              className="underline hover:font-semibold hover:text-secondary-foreground hover:italic"
-            >
-              projects page
-            </Link>
-            ), and to practice my front-end design skills. This website was
-            developed using NextJS, shadcn-ui components, and TailwindCSS.
+            <Typography.Paragraph>
+              I am an aspiring software developer, currently studying a BSc
+              Computer Science degree, in my final year. I am self-taught in
+              programming, and have a strong focus on full-stack, with
+              experience using UNIX-based systems (Linux, and MacOS) and
+              Windows.
+            </Typography.Paragraph>
+            <Typography.Paragraph>
+              This website functions as a portfolio website for future
+              employment (please see the{" "}
+              <Link
+                href="/projects"
+                className="underline hover:font-semibold hover:text-secondary-foreground hover:italic"
+              >
+                projects page
+              </Link>
+              ), and to practice my front-end design skills. This website was
+              developed using NextJS, shadcn-ui components, and TailwindCSS.
+            </Typography.Paragraph>
           </span>
         </CardContent>
         <CardFooter className="flex items-center justify-center">


### PR DESCRIPTION
Add typography components as per the "typography" section of the shadcn/ui docs. Minor adjustments have been made in accordance to my personal preferences.

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request introduces a new typography component to the project. It also updates the home page to use the new typography component for better readability and consistency.
> 
> # What changed
> A new file `typography.tsx` was added to the `src/components` directory. This file exports several functions that return different HTML elements with predefined styles. These functions include `Header1`, `Header2`, `Header3`, `Header4`, `Paragraph`, `Blockquote`, `List`, `InlineCode`, `ParagraphLead`, `Large`, and `Small`.
> 
> The home page (`index.tsx`) was updated to use these new typography components. The text content was wrapped with the `Paragraph` component to apply the predefined styles.
> 
> # How to test
> 1. Pull the changes from this branch to your local environment.
> 2. Run the application.
> 3. Navigate to the home page.
> 4. Verify that the text content is displayed with the new styles.
> 
> # Why make this change
> The new typography components will help maintain consistency in the text styles across the application. It will also make it easier to update the text styles in the future, as the styles are defined in one place.
</details>