### PR TITLE
Add about the D5600

### DIFF
--- a/src/pages/about-me.tsx
+++ b/src/pages/about-me.tsx
@@ -100,9 +100,11 @@ export default function AboutMe() {
                 dad bought himself a new camera, a Nikon D7500, and gave me his
                 then current Nikon D80. While the D80 was already old by this
                 time, it was still a huge upgrade from the FujiFilm - this time
-                actually allowing me to swap lenses!
+                actually allowing me to swap lenses! My usage of the D80
+                deepened my love for the hobby, eventually driving me to buy my
+                own camera at the beginning of my second year of university, a
+                Nikon D5600 - the camera I still use today.
               </Typography.Paragraph>
-              {/* TODO: More about photography */}
             </AccordionContent>
           </AccordionItem>
         </Accordion>


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the `about-me.tsx` page to include more detailed information about my journey into photography. It adds a few lines about my experience with the Nikon D80 and how it influenced my decision to buy my own camera, a Nikon D5600.
> 
> ## What changed
> The `about-me.tsx` page was updated. The changes include additional text about my experience with the Nikon D80 and how it deepened my love for photography, leading me to buy my own Nikon D5600. The `TODO` comment about adding more information about photography was removed as it has been addressed.
> 
> ```diff
> -                actually allowing me to swap lenses!
> +                actually allowing me to swap lenses! My usage of the D80
> +                deepened my love for the hobby, eventually driving me to buy my
> +                own camera at the beginning of my second year of university, a
> +                Nikon D5600 - the camera I still use today.
>                </Typography.Paragraph>
> -              {/* TODO: More about photography */}
> ```
> 
> ## How to test
> To test these changes, navigate to the `about-me.tsx` page and verify that the new text is present and correctly formatted. The new text should provide more detail about my journey into photography.
> 
> ## Why make this change
> This change provides more context and detail about my journey into photography, making the `about-me.tsx` page more informative and engaging for visitors. It also addresses the `TODO` comment about adding more information about photography.
</details>